### PR TITLE
Implement float type alias

### DIFF
--- a/crates/ga_core/src/constants.rs
+++ b/crates/ga_core/src/constants.rs
@@ -1,0 +1,8 @@
+//! Global constants and type definitions that can be used across Ganymede.
+
+/// An alias for the [`f32`](https://doc.rust-lang.org/std/f32/index.html) type.
+///
+/// Throughout Ganymede, all references to floating point values should use this
+/// alias, making it possible to switch to double precision values in the future
+/// if necessary with minimal fuss.
+pub type Float = f32;

--- a/crates/ga_core/src/lib.rs
+++ b/crates/ga_core/src/lib.rs
@@ -1,7 +1,3 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+//! The core of Ganymede, where it all comes together.
+
+pub mod constants;


### PR DESCRIPTION
Closes #9

Float type alias currently set to `f32`. 